### PR TITLE
fix: Number() ではなく parseFloat() で数値かどうかパースする

### DIFF
--- a/src/transformers/numericString.ts
+++ b/src/transformers/numericString.ts
@@ -8,5 +8,7 @@ export class IsNotNumericStringError extends Error {
 }
 
 export const $numericString = Transformer.from<string, number>(text =>
-  Number.isNaN(Number(text)) ? error(ValidationError.from(new IsNotNumericStringError(text))) : ok(Number(text)),
+  Number.isNaN(Number.parseFloat(text))
+    ? error(ValidationError.from(new IsNotNumericStringError(text)))
+    : ok(Number.parseFloat(text)),
 )


### PR DESCRIPTION
Resolves #7 
`/^[+-]?\d+(\.\d+)?$/` みたいなチェックをかけないと `0xf` が `0` になったり `1,234` が `1` になったりしてしんどいかもしれない…